### PR TITLE
docs(start): fix misprint

### DIFF
--- a/docs/start.stories.mdx
+++ b/docs/start.stories.mdx
@@ -14,11 +14,11 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 #### Установите пакет и зависимости
 
-`yarn add @consta/uikit @consta/tree` или `npm install @consta/uikit @consta/gpn-responses`
+`yarn add @consta/uikit @consta/gpn-responses` или `npm install @consta/uikit @consta/gpn-responses`
 
 #### Подключите тему
 
-Тему обязательно нужно подключать в корне приложения, так, чтобы все компоненты `@consta/tree` были вложены в компонент `Theme`.
+Тему обязательно нужно подключать в корне приложения, так, чтобы все компоненты `@consta/gpn-responses` были вложены в компонент `Theme`.
 
 [Как подключить тему](https://consta-uikit.vercel.app/?path=/docs/thematization-how-to-connect-theme--page)
 


### PR DESCRIPTION
closes #1854

Убрала все tree с главной страницы.